### PR TITLE
fix: correct nested API filtering for milestones and tasks

### DIFF
--- a/backend/project/views.py
+++ b/backend/project/views.py
@@ -430,9 +430,9 @@ class MilestoneViewSet(TenantScopedMixin, viewsets.ModelViewSet):
         queryset = super().get_queryset()
 
         # Filter by project if accessed via nested route
-        project_pk = self.kwargs.get('project_pk')
-        if project_pk:
-            queryset = queryset.filter(project__slug=project_pk)
+        project_slug = self.kwargs.get('project_slug')
+        if project_slug:
+            queryset = queryset.filter(project__slug=project_slug)
 
         return queryset.select_related('project').prefetch_related('sprints', 'sprints__tasks')
 
@@ -656,9 +656,9 @@ class TaskViewSet(TenantScopedMixin, viewsets.ModelViewSet):
         queryset = super().get_queryset().select_related('milestone', 'sprint', 'milestone__project')
 
         # Filter by project if accessed via nested route
-        project_pk = self.kwargs.get('project_pk')
-        if project_pk:
-            queryset = queryset.filter(milestone__project__slug=project_pk)
+        project_slug = self.kwargs.get('project_slug')
+        if project_slug:
+            queryset = queryset.filter(milestone__project__slug=project_slug)
 
         # Filter by backlog status
         backlog = self.request.query_params.get('backlog')


### PR DESCRIPTION
- Fix parameter name mismatch in MilestoneViewSet.get_queryset()
- Fix parameter name mismatch in TaskViewSet.get_queryset()
- Change 'project_pk' to 'project_slug' to match URL patterns
- Ensures nested endpoints /api/projects/{slug}/milestones/ and /api/projects/{slug}/tasks/ properly filter by project